### PR TITLE
Add PRD, roadmap summary, and sprint tasks

### DIFF
--- a/docs/vision/PRODUCT_REQUIREMENTS_DOCUMENT.md
+++ b/docs/vision/PRODUCT_REQUIREMENTS_DOCUMENT.md
@@ -1,0 +1,64 @@
+# Dream.OS Product Requirements Document (PRD)
+
+**Version:** 1.0.0
+**Last Updated:** 2025-06-20
+**Status:** DRAFT
+**Author:** Project Contributors
+
+## Purpose
+Dream.OS aims to provide a resilient autonomous agent platform that orchestrates multiple specialized agents in a continuous feedback loop. The system focuses on self‑healing operations, context aware planning, and extensible integrations so agents can solve complex tasks with minimal human oversight.
+
+## Target Users
+- Developers building autonomous agent workflows
+- Researchers exploring multi‑agent coordination
+- Operators deploying the BasicBot or Discord integrations
+
+## Goals & Objectives
+1. Stabilize core agent infrastructure to support continuous autonomous operation
+2. Provide a consistent planning framework with context tracking and verification
+3. Enable seamless external integrations (Discord, web scrapers, API services)
+4. Deliver user facing tools such as dashboards and command interfaces
+
+## Core Features
+### Multi‑Agent Architecture
+- Eight specialized agents with defined roles
+- Mailbox based communication protocol and agent bus events
+- Agent lifecycle management with bootstrap, pause, resume, and terminate actions
+
+### Planning Discipline & Context Management
+- 4‑phase planning process with Strategic → Features → Design → Tasks
+- Context fork tracking and devlog integration
+- Planning step tags embedded in tasks and episodes
+
+### Task System
+- Central task boards for backlog, ready queue, working, and completed tasks
+- File locking and transaction logging to prevent race conditions
+- Validation hooks and duplicate detection
+
+### External Integrations
+- Discord Commander for role based interaction
+- BasicBot deployment with container support
+- Cursor agent bridge for IDE automation
+
+### Monitoring & Metrics
+- Metrics collection for agent responses and resource utilization
+- Telemetry hooks for error logging and drift detection
+- Dashboard and visualization interfaces
+
+## Success Metrics
+- **Stability:** runtime between failures >72h, recovery success >95%
+- **Productivity:** >80% of tasks completed, >90% task validation pass
+- **Integration:** response latency <1s, >85% coordination success
+
+## Dependencies & Risks
+- Ongoing tool reliability issues (`read_file`, `list_dir` failures)
+- Missing bridge modules and Project Board Manager
+- Duplicate tasks and inconsistent planning tags
+
+## Out of Scope
+- Production grade security hardening
+- Large scale cloud deployment automation
+- Long term self learning beyond current roadmap
+
+---
+*This PRD summarizes active requirements derived from existing vision documents.*

--- a/docs/vision/ROADMAP_SUMMARY_2025.md
+++ b/docs/vision/ROADMAP_SUMMARY_2025.md
@@ -1,0 +1,35 @@
+# Dream.OS Roadmap Summary (2025)
+
+**Version:** 1.0.0
+**Last Updated:** 2025-06-20
+**Status:** ACTIVE
+
+This roadmap consolidates the organizational and technical priorities outlined across the project documentation.
+
+## Immediate Tasks (0‑7 Days)
+- **Agent-8:** Implement `test_mailbox_locking.py` to validate concurrency
+- **Agent-5:** Add file locking mechanism for task boards
+- **Agent-2:** Fix mailbox permission issues blocking communication
+- **Agent-3:** Implement `planning_only_mode` check in bootstrap loop
+
+## Short Term (7‑30 Days)
+- Complete remaining bridge modules and integration tests
+- Resolve duplicate tasks and improve validation hooks
+- Enhance autonomous loop recovery and degraded mode protocols
+- Add role-based access control to Discord Commander
+- Create agent status visualization dashboard
+
+## Near Term (30‑90 Days)
+- Launch context routing system and swarm controller
+- Improve documentation system with search and tutorials
+- Implement performance monitoring dashboards
+- Expand external API and webhook integrations
+
+## Long Term (90+ Days)
+- Develop plugin architecture and marketplace for agents
+- Introduce self‑learning mechanisms and knowledge sharing
+- Support multi‑project management with resource allocation
+- Extend AR/VR collaboration interfaces in Digital Dreamscape
+
+---
+*Derived from ORGANIZATIONAL_ROADMAP.md, TECHNICAL_ROADMAP.md and vision updates.*

--- a/docs/vision/SPRINT_TASKS_2025-06-20.md
+++ b/docs/vision/SPRINT_TASKS_2025-06-20.md
@@ -1,0 +1,33 @@
+# Dream.OS Sprint Task List (2025-06-20)
+
+This document summarizes active tasks for each agent based on `runtime/task_board.json`.
+
+## Cursor 1
+- **Current Task:** `BRIDGE-TASK-AGENT-1-EXTRACT-THEA-OUTPUT-001` *(paused by override)*
+- **Pending:** `global_folder_audit_map` *(paused)*, `PROACTIVE-STABILITY-CHECK-001` *(blocked by dependencies)*
+
+## Cursor 2
+- **Current Task:** `audit_utils_helpers` *(executing)* — auditing `utils/` and `helpers/` directories for consolidation
+
+## Cursor 3
+- **Current Task:** `ROUTE_INJECTION_REQUEST` *(phase2 status)*
+  - Subtasks executing: `implement-dreamscape-agents-001`, `CLEANUP-MISC-TODOS-001`, `CONFIG-CENTRAL-001`
+
+## Cursor 4
+- **Current Task:** `audit_shared_functional_misc` *(executing)* — reviewing shared, functional and misc utilities
+
+## Cursor 5
+- **Current Task:** `standardize_scripts` *(executing)* — auditing `scripts/` directories for CLI standards
+
+## Cursor 6
+- **Status:** `IDLE` — monitoring state after completing `INITIAL-BOOTSTRAP-001` and `INVESTIGATE-AGENTBUS-RELIABILITY-001`
+
+## Cursor 7
+- **Current Task:** `sweep_schemas_metadata` *(executing)* — consolidating schema and metadata files
+
+## Cursor 8
+- **Current Task:** `generate_consolidation_report` *(executing)* — compiling structural consolidation report
+  - Recent history includes `scan_for_improvements` and `improve-taskboard-updater-001`
+
+---
+*Last updated from task board timestamp: 2025-05-18T17:29:49Z.*


### PR DESCRIPTION
## Summary
- add high-level PRD describing Dream.OS goals and requirements
- create roadmap summary for 2025 consolidating immediate and long-term tasks
- include sprint task list based on current task board

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ebfb106f4832998404a244eee62d5