### PR TITLE
Add mailbox locking utilities and planning mode support

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,21 @@
+# Dream.OS Product Requirements
+
+This document summarizes the essential goals and features for the Dream.OS project.
+
+## Goals
+- Provide a resilient multi‑agent operating environment.
+- Enable reliable inter‑agent messaging through mailboxes and the AgentBus.
+- Maintain task boards with safe concurrent access.
+- Support planning‑only execution mode for safer testing.
+
+## Core Features
+1. **Agent Mailboxes** – structured directories under `runtime/agent_comms/agent_mailboxes` for exchanging JSON messages.
+2. **Task Boards** – JSON files managed via file locking to avoid corruption.
+3. **Bootstrap Runner** – launches agents and optionally respects `PLANNING_ONLY_MODE` to skip execution.
+4. **Testing Framework** – pytest suite covering bootstrap logic and mailbox locking.
+
+## Current Priorities
+- Stabilize mailbox utilities and permissions.
+- Finalize file locking for task boards and mailboxes.
+- Expand automated tests for critical infrastructure.
+

--- a/docs/vision/ROADMAP_UPDATE.md
+++ b/docs/vision/ROADMAP_UPDATE.md
@@ -1,0 +1,13 @@
+# Short Term Roadmap (Updated)
+
+## Immediate (0‑7 days)
+- **TEST-004**: Verify mailbox locking via `test_mailbox_locking.py`.
+- **TASK-001**: Provide shared file locking utilities for task boards.
+- **INFRA-001**: Ensure mailbox directories have correct permissions.
+- **LOOP-001**: Support `PLANNING_ONLY_MODE` in bootstrap runner.
+
+## Short Term (7‑30 days)
+- Standardize error reporting and agent registry.
+- Expand autonomous loop recovery features.
+- Add dashboard visualizations for agent status.
+

--- a/docs/vision/SPRINT_TASKS.md
+++ b/docs/vision/SPRINT_TASKS.md
@@ -1,0 +1,7 @@
+# Sprint Tasks
+
+1. Finalize and run `test_mailbox_locking.py` to confirm locking behaviour.
+2. Integrate `file_locking` utility across modules that write JSON data.
+3. Update mailbox permissions to 770 on creation.
+4. Use `PLANNING_ONLY_MODE` environment variable to run bootstrap in planning mode.
+

--- a/src/dreamos/core/comms/mailbox_utils.py
+++ b/src/dreamos/core/comms/mailbox_utils.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Utilities for interacting with agent mailboxes."""
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..utils.file_locking import acquire_lock
+
+MAILBOX_ROOT = Path("runtime/agent_comms/agent_mailboxes")
+
+
+def _ensure_mailbox(agent_id: str) -> Path:
+    mailbox = MAILBOX_ROOT / agent_id / "inbox.json"
+    mailbox.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(mailbox.parent, 0o770)
+    if not mailbox.exists():
+        with acquire_lock(mailbox):
+            if not mailbox.exists():
+                temp = mailbox.with_suffix('.tmp')
+                with temp.open('w', encoding='utf-8') as f:
+                    json.dump([], f)
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(temp, mailbox)
+    return mailbox
+
+
+def write_mailbox_message(agent_id: str, message: Dict[str, Any]) -> None:
+    """Append a message to an agent's mailbox using file locking."""
+    mailbox = _ensure_mailbox(agent_id)
+    with acquire_lock(mailbox):
+        try:
+            with mailbox.open("r", encoding="utf-8") as f:
+                messages: List[Dict[str, Any]] = json.load(f)
+        except Exception:
+            messages = []
+        messages.append(message)
+        temp = mailbox.with_suffix(".tmp")
+        with temp.open("w", encoding="utf-8") as f:
+            json.dump(messages, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(temp, mailbox)
+
+
+def read_mailbox_messages(agent_id: str) -> List[Dict[str, Any]]:
+    """Read all messages from an agent's mailbox."""
+    mailbox = _ensure_mailbox(agent_id)
+    with acquire_lock(mailbox):
+        if not mailbox.exists():
+            return []
+        try:
+            with mailbox.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return []
+
+

--- a/src/dreamos/core/utils/file_locking.py
+++ b/src/dreamos/core/utils/file_locking.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Lightweight file locking utilities used across Dream.OS."""
+
+import json
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from filelock import FileLock, Timeout
+
+
+@contextmanager
+def acquire_lock(path: Path, timeout: float = 10.0):
+    """Context manager that acquires a ``FileLock`` for ``path``.
+
+    The lock file is ``path`` with ``.lock`` appended. Raises ``Timeout`` if the
+    lock cannot be acquired within ``timeout`` seconds.
+    """
+    lock = FileLock(str(path.with_suffix(path.suffix + ".lock")))
+    lock.acquire(timeout=timeout)
+    try:
+        yield
+    finally:
+        lock.release()
+
+
+def read_json_locked(path: Path, timeout: float = 10.0) -> Any:
+    """Read JSON data from ``path`` using a file lock."""
+    with acquire_lock(path, timeout=timeout):
+        if not path.exists():
+            return None
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+
+
+def write_json_locked(path: Path, data: Any, timeout: float = 10.0) -> None:
+    """Write JSON data to ``path`` atomically using a lock."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.with_suffix(".tmp")
+    with acquire_lock(path, timeout=timeout):
+        with temp.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(temp, path)
+

--- a/src/dreamos/tools/agent_bootstrap_runner.py
+++ b/src/dreamos/tools/agent_bootstrap_runner.py
@@ -375,6 +375,8 @@ class AgentBootstrapRunner:
                 await asyncio.sleep(self.config.startup_delay_sec)
             
             # Main agent loop
+            planning_only = os.getenv("PLANNING_ONLY_MODE", "false").lower() == "true"
+
             while self.running and not self.shutdown_requested:
                 # Check for context boundaries
                 boundary = self.state_manager.check_context_boundaries()
@@ -386,8 +388,12 @@ class AgentBootstrapRunner:
                 cycle = self.state_manager.increment_cycle_count()
                 self.logger.info(f"Starting cycle {cycle}")
                 
-                # Execute core agent logic
-                success = self._execute_core_agent_logic()
+                # Execute core agent logic unless planning_only_mode is active
+                if planning_only:
+                    self.logger.info("Planning Only Mode enabled - skipping core logic")
+                    success = True
+                else:
+                    success = self._execute_core_agent_logic()
                 
                 # Break after one cycle if configured for once mode
                 if self.config.once:

--- a/src/tests/test_mailbox_locking.py
+++ b/src/tests/test_mailbox_locking.py
@@ -1,0 +1,39 @@
+import concurrent.futures
+import multiprocessing
+import json
+from pathlib import Path
+
+from dreamos.core.comms.mailbox_utils import write_mailbox_message, read_mailbox_messages
+
+
+def _write_message(args):
+    agent_id, msg, mailbox_dir = args
+    from dreamos.core.comms import mailbox_utils
+    mailbox_utils.MAILBOX_ROOT = mailbox_dir
+    message = {"sender": agent_id, "content": msg}
+    write_mailbox_message(agent_id, message)
+
+
+def test_mailbox_locking(tmp_path):
+    mailbox_root = tmp_path / "runtime" / "agent_comms" / "agent_mailboxes"
+    # patch MAILBOX_ROOT for this test
+    from dreamos.core.comms import mailbox_utils
+
+    mailbox_utils.MAILBOX_ROOT = mailbox_root
+
+    agent = "Agent-9"
+    messages = [f"message {i}" for i in range(5)]
+
+    with multiprocessing.Pool(processes=5) as pool:
+        pool.map(_write_message, [(agent, m, mailbox_root) for m in messages])
+
+    inbox = mailbox_root / agent / "inbox.json"
+    assert inbox.exists()
+    with open(inbox, "r") as f:
+        data = json.load(f)
+    assert len(data) == len(messages)
+    contents = [m["content"] for m in data]
+    for msg in messages:
+        assert msg in contents
+
+


### PR DESCRIPTION
## Summary
- add simple `file_locking` utils with atomic JSON read/write
- implement mailbox helpers that use locking and proper permissions
- add `PLANNING_ONLY_MODE` check in the bootstrap runner
- test mailbox locking with multiprocessing
- document product requirements, roadmap update and sprint tasks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ebf32e86c832994b1b4b9463619cb